### PR TITLE
add support for mock mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/flux-burst/tree/main) (0.0.x)
+ - support for mock mode, meaning that we provide a fake job (0.0.11)
  - shared logic in kubernetes module for gke and eks (0.0.1)
  - initial skeleton release of project (0.0.0)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Current and desired plugins are:
 - Who controls cleanup? It can be done by the flux-burst global controller or a plugin, automated or manual, either way.
 - All plugins should have support to read in YAML parameters (some spec for bursting)
 - All plugins should be able to match a resource request to, for example, instance types.
+- Should the plugin "local queue" (self.jobs) assume to be associated with one burst, where the size is the max job size?
+- Should we derive names based on provided name + size so clusters are unique by name and size?
 
 ## 😁️ Contributors 😁️
 

--- a/fluxburst/client.py
+++ b/fluxburst/client.py
@@ -5,9 +5,7 @@
 
 import collections
 
-import flux
-import flux.job
-
+import fluxburst.handles as handles
 import fluxburst.selectors as selectors
 import fluxburst.sorting as sorting
 from fluxburst.logger import logger
@@ -20,7 +18,7 @@ class FluxBurst:
     Flux Burst Client
     """
 
-    def __init__(self, handle=None):
+    def __init__(self, handle=None, mock=False):
         """
         Create a new burst client.
 
@@ -32,7 +30,7 @@ class FluxBurst:
         """
         self.reset_selector()
         self.reset_plugins()
-        self.handle = handle or flux.Flux()
+        self.flux = handles.FluxMock(handle) if mock else handles.FluxHandle(handle)
         self.set_ordering(sorting.in_order)
 
     @property
@@ -175,9 +173,7 @@ class FluxBurst:
 
         # Update the KVS (is this possible)?
         # This doesn't currently work, so not doing anything :)
-        kvs = flux.job.job_kvs(self.handle, job["id"])
-        kvs["jobspec"] = job["spec"]
-        kvs.commit()
+        self.flux.update_jobspec(job)
 
     def select_jobs(self):
         """
@@ -188,11 +184,11 @@ class FluxBurst:
         for bursting. See the README / documentation for example info.
         """
         # Keep track of selected burstable jobs by id
-        listing = flux.job.job_list(self.handle).get()
+        listing = self.flux.list_jobs()
         selected = {}
 
         for job in listing.get("jobs", []):
-            info = self.get_job_info(job["id"])
+            info = self.flux.get_job_info(job["id"])
             if not self._job_selector(info):
                 continue
             print(f"🧋️  Job {job['id']} is marked for bursting.")
@@ -207,26 +203,3 @@ class FluxBurst:
 
     def __str__(self):
         return "[flux-burst-client]"
-
-    def get_job_info(self, jobid):
-        """
-        Get job info based on an id
-
-        Also retrieve the full job info and jobspec.
-        This is not yet currently perfectly json serializable, need to
-        handle EmptyObject if that is desired.
-        """
-        fluxjob = flux.job.JobID(jobid)
-        payload = {"id": fluxjob, "attrs": ["all"]}
-        rpc = flux.job.list.JobListIdRPC(self.handle, "job-list.list-id", payload)
-        job = rpc.get_job()
-
-        # Job info, timing, priority, etc.
-        job["info"] = rpc.get_jobinfo().__dict__
-        job["info"]["_exception"] = job["info"]["_exception"].__dict__
-        job["info"]["_annotations"] = job["info"]["_annotations"].__dict__
-
-        # the KVS will have annotations!
-        kvs = flux.job.job_kvs(self.handle, jobid)
-        job["spec"] = kvs.get("jobspec")
-        return job

--- a/fluxburst/handles.py
+++ b/fluxburst/handles.py
@@ -1,0 +1,228 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+
+
+# We define a FluxHandle class to also provide a mock handle,
+# meaning we aren't running flux, but can provide fake jobs
+
+
+class FluxMock:
+    """
+    A mock flux handle that will return fake jobs, etc.
+
+    This class does not require importing Flux and can be used
+    for testing cases or similar.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def update_jobspec(self, job):
+        """
+        Update a jobspec via the kvs
+        """
+        pass
+
+    def list_jobs(self):
+        """
+        List one fake, burstable job.
+
+        Generated via:
+        flux submit -N 4 --cwd /tmp --setattr=burstable hostname
+        in the fluxrm/flux-sched:focal container on July 2nd 2023. Note that we
+        only use the high level attributes so hosts, etc. do not matter.
+        """
+        return {
+            "jobs": [
+                {
+                    "id": 17839985524736,
+                    "userid": 1002,
+                    "urgency": 16,
+                    "priority": 16,
+                    "t_submit": 1688329701.680035,
+                    "t_depend": 1688329701.693167,
+                    "t_run": 1688329701.709494,
+                    "t_cleanup": 1688329701.7517478,
+                    "t_inactive": 1688329701.753637,
+                    "state": 64,
+                    "name": "hostname",
+                    "cwd": "/tmp",
+                    "ntasks": 4,
+                    "ncores": 16,
+                    "duration": 0.0,
+                    "nnodes": 4,
+                    "ranks": "[0-3]",
+                    "nodelist": "84bd2c990b[15,15,15,15]",
+                    "success": True,
+                    "exception_occurred": False,
+                    "result": 1,
+                    "expiration": 4841929701.0,
+                    "waitstatus": 0,
+                }
+            ]
+        }
+
+    def get_job_info(self, jobid):
+        """
+        Get job info. This is job info (the same function called on the container)
+        job returned above) in the fluxrm/flux-sched:focal container.
+        """
+        return {
+            "id": 17839985524736,
+            "userid": 1002,
+            "urgency": 16,
+            "priority": 16,
+            "t_submit": 1688329701.680035,
+            "t_depend": 1688329701.693167,
+            "t_run": 1688329701.709494,
+            "t_cleanup": 1688329701.7517478,
+            "t_inactive": 1688329701.753637,
+            "state": 64,
+            "name": "hostname",
+            "cwd": "/tmp",
+            "ntasks": 4,
+            "ncores": 16,
+            "duration": 0.0,
+            "nnodes": 4,
+            "ranks": "[0-3]",
+            "nodelist": "84bd2c990b[15,15,15,15]",
+            "success": True,
+            "exception_occurred": False,
+            "result": 1,
+            "expiration": 4841929701.0,
+            "waitstatus": 0,
+            "info": {
+                "_t_depend": 1688329701.693167,
+                "_t_run": 1688329701.709494,
+                "_t_cleanup": 1688329701.7517478,
+                "_t_inactive": 1688329701.753637,
+                "_duration": 0.0,
+                "_expiration": 4841929701.0,
+                "_name": "hostname",
+                "_cwd": "/tmp",
+                "_queue": "",
+                "_ntasks": 4,
+                "_ncores": 16,
+                "_nnodes": 4,
+                "_priority": 16,
+                "_ranks": "[0-3]",
+                "_nodelist": "84bd2c990b[15,15,15,15]",
+                "_success": True,
+                "_waitstatus": 0,
+                "_id": 17839985524736,
+                "_userid": 1002,
+                "_urgency": 16,
+                "_t_submit": 1688329701.680035,
+                "_exception_occurred": False,
+                "_state_id": 64,
+                "_result_id": 1,
+                "_exception": {
+                    "occurred": False,
+                    "severity": "",
+                    "type": "",
+                    "note": "",
+                },
+                "_annotations": {"annotationsDict": {}, "atuple": ()},
+                "_sched": None,
+                "_user": None,
+                "_dependencies": [],
+            },
+            "spec": {
+                "resources": [
+                    {
+                        "type": "node",
+                        "count": 4,
+                        "exclusive": True,
+                        "with": [
+                            {
+                                "type": "slot",
+                                "count": 1,
+                                "with": [{"type": "core", "count": 1}],
+                                "label": "task",
+                            }
+                        ],
+                    }
+                ],
+                "tasks": [
+                    {"command": ["hostname"], "slot": "task", "count": {"per_slot": 1}}
+                ],
+                "attributes": {
+                    "system": {
+                        "duration": 0,
+                        "cwd": "/tmp",
+                        "shell": {
+                            "options": {
+                                "rlimit": {
+                                    "cpu": -1,
+                                    "fsize": -1,
+                                    "data": -1,
+                                    "stack": 8388608,
+                                    "core": -1,
+                                    "nofile": 1048576,
+                                    "as": -1,
+                                    "rss": -1,
+                                    "nproc": -1,
+                                }
+                            }
+                        },
+                        "burstable": 1,
+                    }
+                },
+                "version": 1,
+            },
+        }
+
+
+class FluxHandle:
+    def __init__(self, handle=None):
+        import flux
+
+        self.handle = handle or flux.Flux()
+
+    def update_jobspec(self, job):
+        """
+        Update a jobspec via the kvs
+        """
+        import flux.job
+
+        # Update the KVS (is this possible)?
+        # This doesn't currently work, so not doing anything :)
+        kvs = flux.job.job_kvs(self.handle, job["id"])
+        kvs["jobspec"] = job["spec"]
+        kvs.commit()
+        return kvs
+
+    def list_jobs(self):
+        """
+        List actual jobs from the flux.job module
+        """
+        import flux.job
+
+        return flux.job.job_list(self.handle).get()
+
+    def get_job_info(self, jobid):
+        """
+        Get job info based on an id
+
+        Also retrieve the full job info and jobspec.
+        This is not yet currently perfectly json serializable, need to
+        handle EmptyObject if that is desired.
+        """
+        import flux.job
+
+        fluxjob = flux.job.JobID(jobid)
+        payload = {"id": fluxjob, "attrs": ["all"]}
+        rpc = flux.job.list.JobListIdRPC(self.handle, "job-list.list-id", payload)
+        job = rpc.get_job()
+
+        # Job info, timing, priority, etc.
+        job["info"] = rpc.get_jobinfo().__dict__
+        job["info"]["_exception"] = job["info"]["_exception"].__dict__
+        job["info"]["_annotations"] = job["info"]["_annotations"].__dict__
+
+        # the KVS will have annotations!
+        kvs = flux.job.job_kvs(self.handle, jobid)
+        job["spec"] = kvs.get("jobspec")
+        return job

--- a/fluxburst/plugins.py
+++ b/fluxburst/plugins.py
@@ -36,8 +36,9 @@ class BurstPlugin:
     def __init__(self, dataclass, **kwargs):
         self.set_params(dataclass)
 
-        # Set of jobs assigned to be bursted
+        # Set of jobs assigned to be bursted, and bursted clusters
         self.jobs = {}
+        self.clusters = {}
 
     def schedule(self, job):
         """
@@ -50,6 +51,19 @@ class BurstPlugin:
         Main function to run a plugin with the set of burstable jobs.
         """
         raise NotImplementedError
+
+    def cleanup(self, name=None):
+        pass
+
+    def refresh_clusters(self, clusters):
+        """
+        Update known clusters from a list of those removed.
+        """
+        updated = {}
+        for name in self.clusters:
+            if name not in clusters:
+                updated[name] = self.clusters[name]
+        self.clusters = updated
 
     def set_params(self, dc):
         """


### PR DESCRIPTION
I was wanting to create a flux mock plugin (and I still do) but a much easier approach is to just mock the flux handle from the main flux-burst library here. This will create a faux job that can be used to test a plugin outside of a context that has flux. This also means the burst will be isolated (not connecting to the local cluster) so this should be a mode that is added to each of the burst plugins for testing.