### PR TITLE
allow for instantiation of FluxBurst when handle is not ready

### DIFF
--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -1,5 +1,5 @@
 pre-commit
-black
+black=23.3.0
 isort
 flake8
 pytest

--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -1,5 +1,5 @@
 pre-commit
-black=23.3.0
+black==23.3.0
 isort
 flake8
 pytest

--- a/fluxburst/handles.py
+++ b/fluxburst/handles.py
@@ -177,9 +177,21 @@ class FluxMock:
 
 class FluxHandle:
     def __init__(self, handle=None):
+        self._handle = handle
+
+    @property
+    def handle(self):
+        """
+        A handle propery to "handle" connection! har har.
+
+        We import Flux here to allow instantiating the client possibly
+        after the instance is created.
+        """
         import flux
 
-        self.handle = handle or flux.Flux()
+        if not self._handle:
+            self._handle = flux.Flux()
+        return self._handle
 
     def update_jobspec(self, job):
         """

--- a/fluxburst/utils/__init__.py
+++ b/fluxburst/utils/__init__.py
@@ -18,7 +18,7 @@ from .fileio import (
     write_json,
     write_yaml,
 )
-from .misc import choose, chunks, get_hash, mb_to_bytes, print_bytes, slugify
+from .misc import chunks, get_hash, mb_to_bytes, print_bytes, slugify
 from .terminal import (
     check_install,
     confirm_action,

--- a/fluxburst/utils/misc.py
+++ b/fluxburst/utils/misc.py
@@ -5,8 +5,6 @@
 
 import copy
 
-from pick import pick
-
 
 def chunks(listing, chunk_size):
     """
@@ -41,13 +39,6 @@ def mb_to_bytes(mb):
     Convert mb to bytes, usually so we can derive a better format.
     """
     return mb * (1048576)
-
-
-def choose(options, prompt, default_index=0):
-    """
-    Use pick to choose one of a few options, return the chosen option.
-    """
-    return pick(options, prompt, indicator="=>", default_index=default_index)
 
 
 def get_hash(obj):

--- a/fluxburst/version.py
+++ b/fluxburst/version.py
@@ -21,7 +21,6 @@ INSTALL_REQUIRES = (
     ("rich", {"min_version": None}),
     ("oras", {"min_version": None}),
     ("requests", {"min_version": None}),
-    ("pick", {"min_version": None}),
 )
 
 INSTALL_REQUIRES_KUBERNETES = (


### PR DESCRIPTION
we want to be able to possibly control creating the first instance (e.g., local slurm mock) and the handle may not be ready yet.